### PR TITLE
set secure cookies in jwt-refresh. return 503 on errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The server you configure to use with the React SDK must have a `/token-exchange`
 and optionally a `/jwt-refresh` endpoint if you wish to use refresh tokens.
 
 You can check out `server/routes/token-exchange.js` and `server/routes/jwt-refresh.js` to see how these endpoints are
-implemented.
+implemented.  (Note: the [Known Issue](https://github.com/FusionAuth/fusionauth-react-sdk#known-issues) of multiple requests made to token-exchange may return 503 responses.  These can be ignored.)
 
 At a high level:
 

--- a/server/cookie.js
+++ b/server/cookie.js
@@ -1,0 +1,9 @@
+module.exports = {
+    setSecure: function(res, name, value) {
+        res.cookie(name, value, {
+            httpOnly: true,
+            secure: true,
+            sameSite: 'lax'
+        });
+    }
+}

--- a/server/routes/jwt-refresh.js
+++ b/server/routes/jwt-refresh.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const request = require('request');
 const config = require('../config.js');
+const cookie = require('../cookie.js');
 
 const router = express.Router();
 
@@ -22,8 +23,11 @@ router.post('/', (req, res) => {
 
             (error, response, body) => {
               if (!body.fieldErrors) {
-                res.cookie('access_token', body.token)
-                res.cookie('refresh_token', body.refreshToken)
+                cookie.setSecure(res, 'access_token', body.token);
+                cookie.setSecure(res, 'refresh_token', body.refreshToken);
+                res.sendStatus(204);
+              } else {
+                res.sendStatus(503);
               }
             }
         );

--- a/server/routes/token-exchange.js
+++ b/server/routes/token-exchange.js
@@ -48,7 +48,7 @@ router.post('/', (req, res) => {
                     if (!error) {
                         res.send({user: JSON.parse(body)});
                     } else {
-                      res.sendStatus(503);
+                      res.sendStatus(500);
                     }
                 }
             );

--- a/server/routes/token-exchange.js
+++ b/server/routes/token-exchange.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const request = require('request');
 const config = require('../config.js');
+const cookie = require('../cookie.js');
 
 const router = express.Router();
 
@@ -26,12 +27,12 @@ router.post('/', (req, res) => {
 
     // callback
     (error, response, body) => {
-        console.log("saving tokens as cookies");
-        // save tokens as cookies
         const { access_token, refresh_token } = JSON.parse(body);
         if (access_token && refresh_token) {
-            setSecureCookie(res, 'access_token', access_token);
-            setSecureCookie(res, 'refresh_token', refresh_token);
+            console.log("saving tokens as cookies");
+            // save tokens as cookies
+            cookie.setSecure(res, 'access_token', access_token);
+            cookie.setSecure(res, 'refresh_token', refresh_token);
 
             // submit request to get user information
             request(
@@ -46,24 +47,19 @@ router.post('/', (req, res) => {
                     console.log("getting userinfo");
                     if (!error) {
                         res.send({user: JSON.parse(body)});
+                    } else {
+                      res.sendStatus(503);
                     }
                 }
             );
         } else {
            console.log("Either refresh token or access token is missing.");
            console.log(body);
+           res.sendStatus(503);
         }
 
     }
   );
 });
-
-const setSecureCookie = (res, name, value) => {
-    res.cookie(name, value, {
-        httpOnly: true,
-        secure: true,
-        sameSite: 'lax'
-    });
-}
 
 module.exports = router;


### PR DESCRIPTION
**Summary**:
* jwt-refresh route was not using compatible secure cookies, resulting in stale access_token cookies
* when errors present, routes not returning responses, stacking up pending requests

**Solution**:
* Use the same cookie setting options in jwt-refresh as token-exchange
* res.sendStatus(503) when errors are present