### PR TITLE
add logout route to clear tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,14 +122,15 @@ Three files in particular demonstrate the usage of the SDK. Check out the follow
 ### Server Endpoint Requirements
 
 The server you configure to use with the React SDK must have a `/token-exchange` endpoint to perform the exchange,
-and optionally a `/jwt-refresh` endpoint if you wish to use refresh tokens.
+a `/logout` endpoint to clear tokens, and optionally a `/jwt-refresh` endpoint if you wish to use refresh tokens.
 
-You can check out `server/routes/token-exchange.js` and `server/routes/jwt-refresh.js` to see how these endpoints are
+You can check out `server/routes/token-exchange.js`, `server/routes/logout.js`, and `server/routes/jwt-refresh.js` to see how these endpoints are
 implemented.  (Note: the [Known Issue](https://github.com/FusionAuth/fusionauth-react-sdk#known-issues) of multiple requests made to token-exchange may return 503 responses.  These can be ignored.)
 
 At a high level:
 
 - `token-exchange.js` calls out to the [FusionAuth OAuth Token](https://fusionauth.io/docs/v1/tech/oauth/endpoints#token) endpoint to get an access token and refresh token, which are both stored in secure cookies
 - `jwt-refresh.js` calls out to the [FusionAuth JWT Refresh](https://fusionauth.io/docs/v1/tech/apis/jwt#refresh-a-jwt) endpoint to exchange the refresh token for a new access token
+- `logout.js` clears the access token and refresh tokens
 
 See the [SDK Server Code Requirements](https://github.com/FusionAuth/fusionauth-react-sdk#server-code-requirements) for more detail.

--- a/server/cookie.js
+++ b/server/cookie.js
@@ -1,9 +1,13 @@
 module.exports = {
-    setSecure: function(res, name, value) {
-        res.cookie(name, value, {
+    setSecure: function(res, name, value, maxAge=undefined) {
+        const cookieProps = {
             httpOnly: true,
             secure: true,
             sameSite: 'lax'
-        });
+        };
+        if (typeof(maxAge) !== 'undefined') {
+            cookieProps['maxAge'] = maxAge;
+        }
+        res.cookie(name, value, cookieProps);
     }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -38,6 +38,7 @@ app.use(session(
 // use routes
 app.use('/token-exchange', require('./routes/token-exchange.js'));
 app.use('/jwt-refresh', require('./routes/jwt-refresh.js'));
+app.use('/logout', require('./routes/logout.js'));
 
 // start server
 app.listen(config.serverPort, () => console.log(`FusionAuth example react app listening on port ${config.serverPort}.`));

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fusionauth-example-react-with-sdk-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/server/routes/jwt-refresh.js
+++ b/server/routes/jwt-refresh.js
@@ -31,6 +31,8 @@ router.post('/', (req, res) => {
               }
             }
         );
+    } else {
+      res.sendStatus(400);
     }
 });
 

--- a/server/routes/logout.js
+++ b/server/routes/logout.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const request = require('request');
+const config = require('../config.js');
+const cookie = require('../cookie.js');
+
+const router = express.Router();
+
+router.get('/', (req, res) => {
+  console.log("clearing token cookies");
+  cookie.setSecure(res, 'access_token', '', 0);
+  cookie.setSecure(res, 'refresh_token', '', 0);
+  res.sendStatus(204);
+});
+
+module.exports = router;


### PR DESCRIPTION
**Issue**:
https://github.com/FusionAuth/fusionauth-react-sdk/issues/27
https://github.com/FusionAuth/fusionauth-issues/issues/2023

**Summary**:
When the user logs out, the access_token and refresh_tokens should be cleared.  Otherwise, subsequent requests made by that browser session will send the access_token.  This could be used to continue to provide access to apis until the jwt expires.

**Solution**:
Add /logout route that clears the access_token and refresh_token cookies.

**Linked PR**:
An associated PR in fusionauth-react-sdk will be made.
