### PR TITLE
duplicate field name on queryParams in login/register handlers

### DIFF
--- a/server/routes/login.js
+++ b/server/routes/login.js
@@ -1,10 +1,8 @@
 const express = require('express');
-const request = require('request');
 const config = require('../config.js');
 const cookie = require('../cookie.js');
 const pkce = require('../pkce.js');
 const redirectState = require('../redirectState.js');
-const crypto = require('crypto').webcrypto;
 
 const router = express.Router();
 
@@ -25,7 +23,6 @@ router.get('/', async (req, res) => {
       redirect_uri: token_exchange_uri,
       code_challenge: code.code_challenge,
       code_challenge_method: 'S256',
-      scope: 'openid offline_access',
       state: newState,
   };
   const fullUrl = generateUrl(queryParams);

--- a/server/routes/register.js
+++ b/server/routes/register.js
@@ -1,6 +1,4 @@
 const express = require('express');
-const request = require('request');
-const crypto = require('crypto').webcrypto;
 const config = require('../config.js');
 const cookie = require('../cookie.js');
 const pkce = require('../pkce.js');
@@ -24,7 +22,6 @@ router.get('/', async (req, res) => {
       redirect_uri: redirect_uri,
       code_challenge: code.code_challenge,
       code_challenge_method: 'S256',
-      scope: 'openid offline_access',
       state: newState,
   };
   const fullUrl = generateUrl(queryParams);


### PR DESCRIPTION
Issue #20 highlights that `queryParams.scope` is a duplicate property in the login route handler. The second one will overwrite the first one. I found the register handler to be the same.

I also removed unused modules imported into the files touched.

**Testing**
We want to make sure the login and register flows still work.