### PR TITLE
Add archival note to readme pointing to quickstart example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**This repo is out of date and is archived. Check out [an updated tutorial on using React and the FusionAuth React SDK](https://github.com/FusionAuth/fusionauth-quickstart-javascript-react-web) or [an example server implementation for FusionAuth Web SDKs](https://github.com/FusionAuth/fusionauth-javascript-sdk-express).**
+
 # Example: Using React and the FusionAuth React SDK
 
 This repository contains example usage of the [FusionAuth React SDK](https://github.com/FusionAuth/fusionauth-react-sdk). It provides an example React client that uses the SDK, and an example Express server that is used to complete the OAuth token exchange.


### PR DESCRIPTION
Adding a note to README pointing to the quickstart as the up-to-date example. (based on [this archived README](https://github.com/FusionAuth/fusionauth-example-react-native-0-71))